### PR TITLE
Override map zoom

### DIFF
--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -653,9 +653,9 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
             @Override
             public boolean onScale(ScaleGestureDetector detector) {
               timeDelta = detector.getEventTime() - lastZoomTime;
-              if (lastSpan == -1 || timeDelta < 15 || timeDelta > 30) {
+              if (lastSpan == -1 || timeDelta > 30) {
                 lastSpan = detector.getCurrentSpan();
-              } else if ( timeDelta >= 15 && timeDelta <= 30  &&
+              } else if (timeDelta <= 30  &&
                   ((map.getCameraPosition().zoom +  getZoomValue(detector.getCurrentSpan(), lastSpan) )  < maxZoom )){
                 googleMap.moveCamera(CameraUpdateFactory.zoomBy(getZoomValue(detector.getCurrentSpan(), lastSpan)));
               }
@@ -717,7 +717,7 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
   }
 
   private float getZoomValue(float currentSpan, float lastSpan) {
-    double value = Math.log(currentSpan / lastSpan) / Math.log(9.85);
+    double value = Math.log(currentSpan / lastSpan) / Math.log(12.85);
     return (float) value;
   }
 

--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -262,6 +262,10 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
                 }
               }
 
+              if (jsonParams.has("maxZoom")){
+                maxZoom = jsonParams.getInt("maxZoom");
+              }
+
             }
 
             // Load the class plugin
@@ -340,6 +344,18 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
         mapView.setVisibility(View.INVISIBLE);
       }
     }
+    this.sendNoResult(callbackContext);
+  }
+
+  /**
+   * Set max zoom level of the map
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  @SuppressWarnings("unused")
+  private void setMaxZoom(JSONArray args, CallbackContext callbackContext) throws JSONException {
+    this.maxZoom = args.getInt(0);
     this.sendNoResult(callbackContext);
   }
 

--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -1838,6 +1838,7 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
     if (mapView != null) {
       mapView.onDestroy();
     }
+    gestureDetector = null;
     super.onDestroy();
   }
 

--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -511,10 +511,7 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
     }
 
     if (params.has("maxZoom")){
-      Log.e("client", "-- json has maxZoom");
       maxZoom = params.getInt("maxZoom");
-    } else {
-      Log.e("client", "-- json has NOT maxZoom");
     }
 
     //controls

--- a/src/android/plugin/google/maps/MyPluginLayout.java
+++ b/src/android/plugin/google/maps/MyPluginLayout.java
@@ -373,8 +373,7 @@ public class MyPluginLayout extends FrameLayout  {
       } else {
         String eventName = null;
         if (action == MotionEvent.ACTION_DOWN){
-          MyPluginLayout.this.dragStartsAt(event.getX(), event.getY());
-          Log.e("client", "setting dragging to true and launching the event");
+          MyPluginLayout.this.dragStartsAt(event.getX(), event.getY());          
           myWebView.loadUrl( "javascript:plugin.google.maps.Map._onTouchEvent('maptouchstart');");
         }
       }

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -459,6 +459,16 @@ App.prototype.setZoom = function(zoom) {
     this.set('zoom', zoom);
     cordova.exec(null, this.errorHandler, PLUGIN_NAME, 'exec', ['Map.setZoom', zoom]);
 };
+
+App.prototype.setMaxZoom = function(maxZoom) {
+    this.set('maxZoom', maxZoom);
+    cordova.exec(null, this.errorHandler, PLUGIN_NAME, 'exec', ['Map.setMaxZoom', maxZoom]);
+};
+
+App.prototype.getMaxZoomLevel = function() {
+    return this.get('maxZoom');
+};
+
 App.prototype.panBy = function(x, y) {
     x = parseInt(x, 10);
     y = parseInt(y, 10);

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -306,6 +306,10 @@ App.prototype.getMap = function(div, params) {
       self.set('clickableElementsSelector', params.clickableElementsSelector);
     }
 
+    if (typeof params.maxZoom !== undefined){
+      self.set('maxZoom', params.maxZoom);
+    }
+
     if (!isDom(div)) {
         params = div;
         params = params || {};


### PR DESCRIPTION
- Avoids map dragging while zooming (just like Uber does).
- Handles max zoom from the plugin directly.
